### PR TITLE
resolve session race conditions and expired-token broken routes

### DIFF
--- a/backend/src/middlewares/Auth.middleware.js
+++ b/backend/src/middlewares/Auth.middleware.js
@@ -1,37 +1,78 @@
 const jwt = require('jsonwebtoken');
 const { isBlacklistedToken } = require('../lib/cache');
 
-const verifyToken = async (req, res, next) => {
-    const authHeader = req.headers["authorization"];
-    const token = authHeader?.startsWith("Bearer ") ? authHeader.split(" ")[1] : authHeader;
-    if (!token) return res.status(401).json({ error: "Access denied, token required" });
+/**
+ * verifyToken
+ *
+ * Express middleware that validates the JWT access token on every protected
+ * request. Rejects with structured 401 responses for each distinct failure
+ * mode so the frontend interceptor can distinguish them cleanly.
+ *
+ * Failure modes and their HTTP responses:
+ *   - Missing token           → 401 { error: 'Access denied, token required' }
+ *   - Blacklisted token       → 401 { message: 'Token has been revoked' }
+ *   - Expired token           → 401 { message: 'Token expired', code: 'TOKEN_EXPIRED' }
+ *   - Malformed/invalid token → 401 { message: 'Invalid token', code: 'TOKEN_INVALID' }
+ *
+ * The `code` field on expiry/invalid responses allows the Axios interceptor
+ * to decide whether to attempt a silent refresh (TOKEN_EXPIRED) or bail out
+ * immediately (TOKEN_INVALID).
+ */
+const verifyToken = (req, res, next) => {
+    const authHeader = req.headers['authorization'];
+    const token = authHeader?.startsWith('Bearer ')
+        ? authHeader.split(' ')[1]
+        : authHeader;
+
+    if (!token) {
+        return res.status(401).json({ error: 'Access denied, token required' });
+    }
+
+    if (isBlacklistedToken(token)) {
+        return res.status(401).json({ message: 'Token has been revoked' });
+    }
 
     try {
-        if (isBlacklistedToken(token)) {
-            return res.status(401).json({ message: 'blacklisted token' });
+        const decoded = jwt.verify(token, process.env.JWT_ACCESS_KEY);
+        req.user = {
+            id: decoded.sub,
+            role: decoded.role,
+        };
+        next();
+    } catch (err) {
+        if (err.name === 'TokenExpiredError') {
+            return res.status(401).json({
+                message: 'Token expired',
+                code: 'TOKEN_EXPIRED',
+            });
         }
 
-        jwt.verify(token, process.env.JWT_ACCESS_KEY, (err, decoded) => {
-            if (err) {
-                if (err.name === 'TokenExpiredError') {
-                    return res.status(401).json({ message: 'Token expired' });
-                }
-                return res.status(401).json({ message: 'Invalid token in verifying' });
-            }
-            req.user = {
-                id: decoded.sub,
-                role: decoded.role
-            };
-            next();
+        if (err.name === 'JsonWebTokenError') {
+            return res.status(401).json({
+                message: 'Invalid token',
+                code: 'TOKEN_INVALID',
+            });
+        }
+
+        // Unexpected verification error (e.g. algorithm mismatch)
+        return res.status(401).json({
+            message: 'Token verification failed',
+            code: 'TOKEN_ERROR',
         });
-    } catch (error) {
-        res.status(401).json({ error: "Invalid token" });
     }
-}
+};
+
+/**
+ * adminChecks
+ *
+ * Must be chained after verifyToken. Ensures the authenticated user has the
+ * 'admin' role before allowing access to admin-only routes.
+ */
 const adminChecks = (req, res, next) => {
     if (req.user?.role !== 'admin') {
         return res.status(403).json({ message: 'Forbidden: Admin access required' });
     }
     next();
 };
-module.exports = { verifyToken,adminChecks };
+
+module.exports = { verifyToken, adminChecks };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { Toaster } from '@/components/ui/sonner';
-import { getStoredUser, getStoredTokens } from '@/api';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import NavigationService from '@/lib/navigationService';
 import Navbar from '@/components/Navbar.jsx';
 import Landing from '@/pages/Landing.jsx';
 
@@ -20,64 +21,102 @@ const AdminDestinations = React.lazy(() => import('@/pages/admin/AdminDestinatio
 const AdminUsers = React.lazy(() => import('@/pages/admin/AdminUsers'));
 const AdminAnalytics = React.lazy(() => import('@/pages/admin/AdminAnalytics'));
 
-function App() {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+// ─── Splash Screen ───────────────────────────────────────────────────────────
+// Shown while AuthContext is validating the stored session on startup.
+// Prevents any protected route from rendering before auth state is resolved.
 
+const SplashScreen = () => (
+  <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="text-center">
+      <div className="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+      <p className="text-muted-foreground text-sm font-medium">Loading…</p>
+    </div>
+  </div>
+);
+
+// ─── Route Guards ────────────────────────────────────────────────────────────
+// Defined OUTSIDE the App render function so React never unmounts/remounts
+// them on re-renders (avoids the flashing-UI bug from closure recreation).
+
+const ProtectedRoute = ({ children }) => {
+  const { authStatus } = useAuth();
+  if (authStatus === 'loading') return <SplashScreen />;
+  return authStatus === 'authenticated' ? children : <Navigate to="/login" replace />;
+};
+
+const PublicRoute = ({ children }) => {
+  const { authStatus } = useAuth();
+  if (authStatus === 'loading') return <SplashScreen />;
+  return authStatus === 'unauthenticated' ? children : <Navigate to="/" replace />;
+};
+
+const AdminRoute = ({ children }) => {
+  const { user, authStatus } = useAuth();
+  if (authStatus === 'loading') return <SplashScreen />;
+  if (authStatus === 'unauthenticated') return <Navigate to="/login" replace />;
+  if (user?.role !== 'admin') return <Navigate to="/" replace />;
+  return children;
+};
+
+// ─── NavigationService Registrar ─────────────────────────────────────────────
+// A tiny component that lives inside <BrowserRouter> so it has access to
+// useNavigate(). It registers the navigate fn with NavigationService once,
+// enabling the Axios interceptor to use client-side routing.
+
+const NavigationRegistrar = () => {
+  const navigate = useNavigate();
   useEffect(() => {
-    const storedUser = getStoredUser();
-    const { accessToken } = getStoredTokens();
+    NavigationService.setNavigate(navigate);
+  }, [navigate]);
+  return null;
+};
 
-    if (storedUser && accessToken) {
-      setUser(storedUser);
-    }
-    setLoading(false);
-  }, []);
+// ─── Router Content ───────────────────────────────────────────────────────────
+// Extracted so that NavigationRegistrar is always rendered inside <BrowserRouter>.
 
-  const ProtectedRoute = ({ children }) => {
-    if (loading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
-    return user ? children : <Navigate to="/login" />;
-  };
+const AppRoutes = () => {
+  const { user, logout } = useAuth();
 
-  const PublicRoute = ({ children }) => {
-    if (loading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
-    return !user ? children : <Navigate to="/" />;
-  };
+  return (
+    <>
+      <NavigationRegistrar />
+      <Navbar user={user} onLogout={logout} />
+      <React.Suspense fallback={<SplashScreen />}>
+        <Routes>
+          <Route path="/" element={<Landing user={user} />} />
+          <Route path="/login" element={<PublicRoute><Login /></PublicRoute>} />
+          <Route path="/signup" element={<PublicRoute><Signup /></PublicRoute>} />
+          <Route path="/forgot-password" element={<PublicRoute><ForgotPassword /></PublicRoute>} />
+          <Route path="/reset-password" element={<PublicRoute><ResetPassword /></PublicRoute>} />
+          <Route path="/survey" element={<ProtectedRoute><Survey /></ProtectedRoute>} />
+          <Route path="/thank-you" element={<ProtectedRoute><ThankYou /></ProtectedRoute>} />
+          <Route path="/recommendations" element={<ProtectedRoute><Recommendations /></ProtectedRoute>} />
+          <Route path="/destination/:id" element={<ProtectedRoute><DestinationDetail /></ProtectedRoute>} />
+          <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
 
-  const AdminRoute = ({ user, children }) => {
-    if (loading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
-    if (!user) return <Navigate to="/login" replace />;
-    if (user.role !== 'admin') return <Navigate to="/" replace />;
-    return children;
-  };
+          {/* Admin Routes */}
+          <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>}>
+            <Route index element={<AdminAnalytics />} />
+            <Route path="destinations" element={<AdminDestinations />} />
+            <Route path="users" element={<AdminUsers />} />
+            <Route path="analytics" element={<AdminAnalytics />} />
+          </Route>
+        </Routes>
+      </React.Suspense>
+      <Toaster position="top-right" />
+    </>
+  );
+};
 
+// ─── App Root ─────────────────────────────────────────────────────────────────
+
+function App() {
   return (
     <div className="App relative min-h-screen bg-background text-foreground transition-colors duration-300 z-[1]">
       <BrowserRouter>
-        <Navbar user={user} setUser={setUser} />
-        <React.Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
-          <Routes>
-            <Route path="/" element={<Landing user={user} />} />
-            <Route path="/login" element={<PublicRoute><Login setUser={setUser} /></PublicRoute>} />
-            <Route path="/signup" element={<PublicRoute><Signup setUser={setUser} /></PublicRoute>} />
-            <Route path="/forgot-password" element={<PublicRoute><ForgotPassword /></PublicRoute>} />
-            <Route path="/reset-password" element={<PublicRoute><ResetPassword /></PublicRoute>} />
-            <Route path="/survey" element={<ProtectedRoute><Survey /></ProtectedRoute>} />
-            <Route path="/thank-you" element={<ProtectedRoute><ThankYou /></ProtectedRoute>} />
-            <Route path="/recommendations" element={<ProtectedRoute><Recommendations /></ProtectedRoute>} />
-            <Route path="/destination/:id" element={<ProtectedRoute><DestinationDetail /></ProtectedRoute>} />
-            <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
-
-            {/* Admin Routes */}
-            <Route path="/admin" element={<AdminRoute user={user}><AdminDashboard setUser={setUser} /></AdminRoute>}>
-              <Route index element={<AdminAnalytics />} />
-              <Route path="destinations" element={<AdminDestinations />} />
-              <Route path="users" element={<AdminUsers />} />
-              <Route path="analytics" element={<AdminAnalytics />} />
-            </Route>
-          </Routes>
-        </React.Suspense>
-        <Toaster position="top-right" />
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
       </BrowserRouter>
     </div>
   );

--- a/frontend/src/api.jsx
+++ b/frontend/src/api.jsx
@@ -1,8 +1,28 @@
 import axios from 'axios';
+import NavigationService from '@/lib/navigationService';
 
 // Use relative path for dev (via Vite proxy), full URL for production
 const apiBase = import.meta.env.VITE_Backend_API || (import.meta.env.DEV ? '/api' : 'http://localhost:9000/api');
 const API = apiBase.replace(/\/+$/, '');
+
+/**
+ * Decode a JWT payload and check whether the token has expired.
+ * This is a CLIENT-SIDE only check (no signature verification).
+ * Used at app startup to avoid treating a stale localStorage token as valid.
+ *
+ * @param {string} token - A JWT string
+ * @returns {boolean} true if the token is expired or unparseable
+ */
+export const isTokenExpired = (token) => {
+  if (!token) return true;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    // exp is in seconds; Date.now() is in milliseconds
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+};
 
 export const setAuthToken = (token) => {
   if (token) {
@@ -128,7 +148,7 @@ axios.interceptors.response.use(
       } catch (refreshError) {
         processQueue(refreshError, null);
         clearTokens();
-        window.location.href = '/login';
+        NavigationService.navigate('/login', { replace: true });
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,24 +1,20 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Compass, User, LogOut, Sun, Moon, Menu, X, Shield } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { logout } from '@/api.jsx';
 import { toast } from 'sonner';
 import { useTheme } from '@/components/theme-provider.jsx';
 import ActionButton from '@/components/ActionButton.jsx';
 
-const Navbar = ({ user, setUser }) => {
+const Navbar = ({ user, onLogout }) => {
   const MotionDiv = motion.div;
-  const navigate = useNavigate();
   const { theme, setTheme } = useTheme();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const handleLogout = async () => {
-    await logout();
-    setUser(null);
     setIsMobileMenuOpen(false);
+    await onLogout();
     toast.success('Logged out successfully');
-    navigate('/');
   };
 
   const NavLinks = ({ onClick }) => (

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,170 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import {
+  getStoredUser,
+  getStoredTokens,
+  storeUser,
+  storeTokens,
+  clearTokens,
+  isTokenExpired,
+  refreshAccessToken,
+  logout as apiLogout,
+} from '@/api';
+import NavigationService from '@/lib/navigationService';
+
+/**
+ * AuthContext
+ *
+ * Provides a single source of truth for authentication state across the app.
+ *
+ * authStatus values:
+ *   'loading'         — startup validation is in progress; render a splash screen
+ *   'authenticated'   — user session is valid; protected routes may render
+ *   'unauthenticated' — no valid session; redirect to /login
+ *
+ * Why this exists:
+ *   The previous pattern stored user state directly in App.jsx via useState and
+ *   read it from localStorage without checking token expiry. This caused three
+ *   problems:
+ *     1. An expired token in localStorage was treated as a valid session, so
+ *        protected APIs fired before the 401 interceptor could act.
+ *     2. Route guards were recreated on every App render (closures inside render).
+ *     3. logout() lived in multiple places (Navbar, interceptor) with no
+ *        coordination, causing race conditions between redirects.
+ */
+
+// ─── Context ────────────────────────────────────────────────────────────────
+
+const AuthContext = createContext(null);
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [authStatus, setAuthStatus] = useState('loading');
+
+  /**
+   * initializeAuth
+   *
+   * Runs once on app startup. Implements the startup state machine:
+   *
+   *   APP_START
+   *     ↓
+   *   LOAD_LOCAL_SESSION
+   *     ↓
+   *   VALIDATE_ACCESS_TOKEN (client-side exp check — no API call)
+   *     ↓
+   *   REFRESH_IF_REQUIRED   (one API call, only when needed)
+   *     ↓
+   *   AUTH_SUCCESS  → set status 'authenticated'
+   *   AUTH_FAILURE  → clear state, set status 'unauthenticated'
+   */
+  useEffect(() => {
+    let cancelled = false;
+
+    const initializeAuth = async () => {
+      const storedUser = getStoredUser();
+      const { accessToken, refreshToken } = getStoredTokens();
+
+      // No session at all → go straight to unauthenticated
+      if (!storedUser || !accessToken) {
+        if (!cancelled) setAuthStatus('unauthenticated');
+        return;
+      }
+
+      // Access token still valid → restore session immediately
+      if (!isTokenExpired(accessToken)) {
+        if (!cancelled) {
+          setUser(storedUser);
+          setAuthStatus('authenticated');
+        }
+        return;
+      }
+
+      // Access token expired — try to silently refresh using the refresh token
+      if (!refreshToken || isTokenExpired(refreshToken)) {
+        // Both tokens dead → force logout
+        clearTokens();
+        if (!cancelled) setAuthStatus('unauthenticated');
+        return;
+      }
+
+      try {
+        const newAccessToken = await refreshAccessToken();
+        // refreshAccessToken already calls storeTokens() internally
+        if (!cancelled) {
+          setUser(storedUser);
+          setAuthStatus('authenticated');
+        }
+      } catch {
+        // Refresh failed (revoked, network error, etc.) → clean logout
+        clearTokens();
+        if (!cancelled) setAuthStatus('unauthenticated');
+      }
+    };
+
+    initializeAuth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /**
+   * login
+   * Called after a successful login/signup API response to hydrate auth state.
+   *
+   * @param {object} userData  - The user object returned by the API
+   * @param {string} accessToken
+   * @param {string} refreshToken
+   */
+  const login = useCallback((userData, accessToken, refreshToken) => {
+    storeTokens(accessToken, refreshToken);
+    storeUser(userData);
+    setUser(userData);
+    setAuthStatus('authenticated');
+  }, []);
+
+  /**
+   * logout
+   * Centralized logout — the single place that:
+   *   1. Calls the backend to blacklist tokens
+   *   2. Clears all local state and storage
+   *   3. Navigates to the login page
+   *
+   * All other logout triggers (Navbar button, 401 interceptor) should call
+   * this function so that state is always cleaned up consistently.
+   */
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } catch {
+      // Backend logout is best-effort; proceed regardless
+    } finally {
+      clearTokens();
+      setUser(null);
+      setAuthStatus('unauthenticated');
+      NavigationService.navigate('/', { replace: true });
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, authStatus, login, logout, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+/**
+ * useAuth
+ * Consume the AuthContext from any component.
+ * Throws if used outside of <AuthProvider>.
+ */
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an <AuthProvider>');
+  }
+  return ctx;
+};

--- a/frontend/src/lib/navigationService.js
+++ b/frontend/src/lib/navigationService.js
@@ -1,0 +1,49 @@
+/**
+ * NavigationService
+ *
+ * A singleton that holds a reference to React Router's `navigate` function.
+ * This allows non-React modules (e.g. the Axios interceptor in api.jsx) to
+ * trigger client-side navigation without resorting to `window.location.href`,
+ * which bypasses the router and produces "Page Not Found" errors.
+ *
+ * Usage:
+ *   // In your root component (App.jsx), once:
+ *   NavigationService.setNavigate(navigate);
+ *
+ *   // Anywhere else (e.g. api.jsx interceptor):
+ *   NavigationService.navigate('/login');
+ */
+
+const NavigationService = (() => {
+  let _navigate = null;
+
+  return {
+    /**
+     * Register the React Router navigate function.
+     * Call this once from the root component after the router is mounted.
+     * @param {Function} navigateFn - The `navigate` function from `useNavigate()`
+     */
+    setNavigate(navigateFn) {
+      _navigate = navigateFn;
+    },
+
+    /**
+     * Navigate to a path using React Router.
+     * Falls back to `window.location.href` only if the router is not yet
+     * registered (e.g. during very early startup before the root mounts).
+     * @param {string} path - The target route path
+     * @param {object} [options] - Optional React Router navigate options
+     */
+    navigate(path, options = {}) {
+      if (_navigate) {
+        _navigate(path, options);
+      } else {
+        // Fallback: router not yet registered. This should only happen in
+        // edge cases during very early startup.
+        window.location.href = path;
+      }
+    },
+  };
+})();
+
+export default NavigationService;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { login } from "@/api.jsx";
+import { login as apiLogin } from "@/api.jsx";
+import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "sonner";
 import { Eye, EyeOff } from "lucide-react";
 import { motion } from "framer-motion";
 import ActionButton from "@/components/ActionButton.jsx";
 
-const Login = ({ setUser }) => {
+const Login = () => {
   const MotionDiv = motion.div;
+  const { login } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -19,8 +21,8 @@ const Login = ({ setUser }) => {
     setLoading(true);
 
     try {
-      const data = await login(email, password);
-      setUser(data.user);
+      const data = await apiLogin(email, password);
+      login(data.user, data.access_token, data.refresh_token);
       toast.success("Login successful!");
       navigate("/");
     } catch (error) {

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { signup } from "@/api.jsx";
+import { signup as apiSignup } from "@/api.jsx";
+import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "sonner";
 import { Eye, EyeOff } from "lucide-react";
 import { motion } from "framer-motion";
 import ActionButton from "@/components/ActionButton.jsx";
 
-const Signup = ({ setUser }) => {
+const Signup = () => {
   const MotionDiv = motion.div;
+  const { login } = useAuth();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -20,8 +22,8 @@ const Signup = ({ setUser }) => {
     setLoading(true);
 
     try {
-      const data = await signup(email, password, name);
-      setUser(data.user);
+      const data = await apiSignup(email, password, name);
+      login(data.user, data.access_token, data.refresh_token);
       toast.success("Account created successfully!");
       navigate("/survey", { replace: true });
     } catch (error) {

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { LayoutDashboard, MapPin, Users, BarChart2, LogOut, ChevronLeft } from 'lucide-react';
-import { logout } from '@/api.jsx';
+import { useAuth } from '@/contexts/AuthContext';
 
 const sidebarLinks = [
   { to: '/admin',              label: 'Overview',     icon: LayoutDashboard, end: true },
@@ -10,13 +10,12 @@ const sidebarLinks = [
   { to: '/admin/analytics',    label: 'Analytics',    icon: BarChart2 },
 ];
 
-export default function AdminDashboard({ setUser }) {
+export default function AdminDashboard() {
   const navigate = useNavigate();
+  const { logout } = useAuth();
 
   const handleLogout = async () => {
     await logout();
-    setUser(null);
-    navigate('/');
   };
 
   return (


### PR DESCRIPTION

## Problem

When a user reopened the app with an expired access token, the following
sequence occurred:

  1. App mounted and read `user` + `accessToken` from localStorage
  2. Token presence was accepted as a valid session (expiry was never checked)
  3. Protected routes rendered and fired API calls immediately
  4. The 401 interceptor detected the expired token and tried to redirect
  5. The redirect used `window.location.href = '/login'` — a full browser
     reload that tore down the React tree
  6. React Router had not yet registered `/login` at the moment of that reload
  7. User landed on **Page Not Found**

The same code path also caused:
  - Premature protected API calls before auth was confirmed
  - Route guard components recreated on every render (flash / remount)
  - Multiple disconnected logout paths racing each other

## Root Cause Analysis

| # | Location | Bug |
|---|----------|-----|
| 1 | `App.jsx` | Auth init checked token **presence** only — never decoded `exp` |
| 2 | `api.jsx` | `window.location.href = '/login'` bypasses React Router entirely |
| 3 | `App.jsx` | Route guard components defined inside render fn — recreated every cycle |
| 4 | `App.jsx` + 3 pages | `setUser` prop-drilled to Navbar/Login/Signup/AdminDashboard — fragmented logout |
| 5 | `Auth.middleware.js` | `jwt.verify` callback nested inside `async` function — errors could be swallowed |
| 6 | `Auth.middleware.js` | All 401s returned the same shape — interceptor couldn't tell expired from invalid |

## Changes

### `frontend/src/lib/navigationService.js` *(new)*
Singleton that holds a reference to React Router's `navigate()` fn.
Allows non-React modules (Axios interceptor) to perform client-side
navigation without touching `window.location`.

### `frontend/src/api.jsx`
- Import and use `NavigationService.navigate('/login', { replace: true })`
  instead of `window.location.href` in the 401 error interceptor
- Export `isTokenExpired(token)` — decodes the JWT `exp` claim client-side
  (no signature check) so `AuthContext` can validate tokens at startup
  without an extra API round-trip

### `frontend/src/contexts/AuthContext.jsx` *(new)*
Proper auth state machine — the single source of truth for auth state.

```
authStatus: 'loading' | 'authenticated' | 'unauthenticated'

APP_START
  ↓
LOAD_LOCAL_SESSION
  ↓
VALIDATE_ACCESS_TOKEN  ← client-side exp decode, no API call
  ↓ valid                  ↓ expired
authenticated          REFRESH_IF_REQUIRED
                         ↓ ok      ↓ dead
                       auth'd   clear → unauth'd
```

Exports `AuthProvider`, `useAuth()` with `{ user, authStatus, login, logout }`.
Protected routes must not render while `authStatus === 'loading'`.

### `frontend/src/App.jsx`
- Wrap tree in `<AuthProvider>`
- Add `<NavigationRegistrar>` (inside `<BrowserRouter>`) to register
  `navigate` with `NavigationService` once on mount
- Move `ProtectedRoute`, `PublicRoute`, `AdminRoute` **outside** the
  render function — they are now stable component definitions, not
  closures recreated every cycle
- Route guards read auth state via `useAuth()` instead of props
- Global `<SplashScreen>` shown while `authStatus === 'loading'`

### `frontend/src/components/Navbar.jsx`
- Accept `onLogout` callback prop instead of `setUser`
- Remove internal `logout()` + `setUser(null)` + `navigate('/')` —
  all delegated to `AuthContext.logout()`

### `frontend/src/pages/Login.jsx` & `Signup.jsx`
- Remove `setUser` prop dependency
- Call `useAuth().login(user, accessToken, refreshToken)` after success
  so `AuthContext` is the only writer of auth state

### `frontend/src/pages/admin/AdminDashboard.jsx`
- Remove `setUser` prop and duplicate logout logic
- Call `useAuth().logout()` which handles state + navigation

### `backend/src/middlewares/Auth.middleware.js`
- Replace `jwt.verify()` callback-in-async with synchronous try/catch
- Add structured error `code` field to 401 responses:
  - `TOKEN_EXPIRED`  — interceptor may attempt silent refresh
  - `TOKEN_INVALID`  — bad signature / malformed; do not retry
  - `TOKEN_ERROR`    — unexpected verification failure
- Improve blacklist rejection message clarity

## Testing

Manual scenarios verified:
| Scenario | Result |
|----------|--------|
| No token in storage | `/` renders (public), no errors |
| Valid token in storage | Session restored, protected routes work |
| Expired access + valid refresh | Silent refresh on startup, auth restored |
| Both tokens expired | Cleaned state, redirect to `/login` via React Router |
| Logout | State cleared, navigate to `/`, no stale data |
| Multiple simultaneous 401s | Single refresh fires, others queue and retry |
```